### PR TITLE
Add warpbox around main logo

### DIFF
--- a/src/components/Main/Main.jsx
+++ b/src/components/Main/Main.jsx
@@ -160,7 +160,9 @@ const Main = () => {
               </div>
             </div>
             <div className="col-xl-4 col-lg-4 col-md-4 mb-5 pt-4 mt-5">
-              <img src={I} className="mainimages" alt="Logo" />
+              <WarpBox radius={50} strength={-0.12}>
+                <img src={I} className="mainimages" alt="Logo" />
+              </WarpBox>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- wrap the `logo4.png` image in a WarpBox so it appears with the warp effect on the main page

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df0832ba48320a07d12e156592ecb